### PR TITLE
Fix: Add UTF-8 encoding when reading workflow files

### DIFF
--- a/img_generator.py
+++ b/img_generator.py
@@ -179,7 +179,7 @@ def main_generation_loop(config, num_iterations):
         print(f"\n--- Itération {i}/{num_iterations} ---")
 
         # 1. Load workflow template
-        with open(config['workflow_file'], 'r') as f:
+        with open(config['workflow_file'], 'r', encoding='utf-8') as f:
             workflow = json.load(f)
 
         # 2. Generate prompt


### PR DESCRIPTION
The script was failing with an 'invalid prompt' error from the ComfyUI server, indicating a node was missing the 'class_type' property with a strange 'Node ID '#id''.

This was caused by a character encoding issue when reading the workflow JSON files, which contain non-ASCII characters. The `open()` function was called without specifying an encoding, leading to data corruption on systems with a default encoding other than UTF-8.

This change fixes the issue by explicitly setting `encoding='utf-8'` when opening the workflow files in `img_generator.py`, ensuring the files are read correctly regardless of the system's default encoding.