### PR TITLE
Feat: Improve LLM prompt template for cleaner output

### DIFF
--- a/img_generator.py
+++ b/img_generator.py
@@ -85,7 +85,7 @@ def call_ollama(prompt_template, input_data):
 
 def generate_prompt_only(base_prompt):
     """Generates a detailed prompt without LoRA syntax."""
-    prompt_template = "You are a prompt generation expert. Create a detailed, imaginative prompt from this basic description: {}"
+    prompt_template = "You are a prompt generation expert. Your task is to expand a basic description into a detailed, imaginative prompt. Respond with ONLY the detailed prompt, without any introduction, explanation, or questions. The basic description is: {}"
     return call_ollama(prompt_template, base_prompt)
 
 def select_lora_with_llm(prompt, config):
@@ -116,10 +116,6 @@ def update_workflow(workflow_data, config, prompt, lora_name):
 
 def queue_prompt(workflow):
     """Queues a prompt on the ComfyUI server."""
-    print("--- DEBUG: Workflow being sent to ComfyUI ---")
-    # Using json.dumps for pretty printing the workflow
-    print(json.dumps(workflow, indent=2, ensure_ascii=False))
-    print("---------------------------------------------")
     payload = {"prompt": workflow}
     try:
         response = requests.post(f"{COMFYUI_URL}/prompt", json=payload)
@@ -183,7 +179,7 @@ def main_generation_loop(config, num_iterations):
         print(f"\n--- Itération {i}/{num_iterations} ---")
 
         # 1. Load workflow template
-        with open(config['workflow_file'], 'r') as f:
+        with open(config['workflow_file'], 'r', encoding='utf-8') as f:
             workflow = json.load(f)
 
         # 2. Generate prompt


### PR DESCRIPTION
The LLM was returning conversational text, including an introduction and follow-up questions, instead of just the image prompt. This polluted the data being sent to ComfyUI.

This commit updates the prompt template in the `generate_prompt_only` function to be more specific. It now explicitly instructs the LLM to respond with ONLY the detailed prompt, ensuring a clean output that can be directly used in the workflow.