### PR TITLE
Debug: Bypass LLM calls to isolate error

### DIFF
--- a/img_generator.py
+++ b/img_generator.py
@@ -182,20 +182,13 @@ def main_generation_loop(config, num_iterations):
         with open(config['workflow_file'], 'r', encoding='utf-8') as f:
             workflow = json.load(f)
 
-        # 2. Generate prompt
-        base_prompt, _ = generate_random_prompt()
-        prompt = generate_prompt_only(base_prompt)
-        if not prompt:
-            print("⚠️ Impossible de générer un prompt, passage à l'itération suivante.")
-            continue
-        print(f"📝 Prompt: {prompt[:100]}...")
-        
-        # 3. Select LoRA
-        lora = select_lora_with_llm(prompt, config)
-        if not lora:
-            print("⚠️ Impossible de sélectionner un LoRA.")
-        else:
-            print(f"🎨 LoRA: {lora}")
+        # 2. Generate prompt (DEBUG: Hardcoded)
+        prompt = "a beautiful landscape, cinematic, dramatic lighting"
+        print(f"📝 Prompt (DEBUG): {prompt[:100]}...")
+
+        # 3. Select LoRA (DEBUG: Bypassed)
+        lora = None
+        print("🎨 LoRA (DEBUG): Bypassed")
 
         # 4. Update workflow and queue for generation
         updated_workflow = update_workflow(workflow, config, prompt, lora)


### PR DESCRIPTION
This is a temporary debugging change to isolate the source of the persistent 'invalid prompt' error.

This commit modifies the `main_generation_loop` to bypass the calls to the Ollama language model for prompt generation and LoRA selection. Instead, it uses a simple hardcoded prompt and no LoRA.

The purpose of this change is to determine if the error lies within the LLM interaction or in the core workflow processing. This is not a permanent solution and should not be merged into the main branch.