### PR TITLE
fix: Correct polling logic in get_image function

### DIFF
--- a/img_generator.py
+++ b/img_generator.py
@@ -181,7 +181,6 @@ def get_image(prompt_id):
                         if os.path.exists(img_path):
                             with open(img_path, 'rb') as f:
                                 return f.read()
-                return None # Still processing
             time.sleep(2)
         except requests.RequestException as e:
             print(f"❌ Erreur de connexion à ComfyUI : {e}")


### PR DESCRIPTION
The `get_image` function was exiting prematurely if the ComfyUI history API indicated that the outputs were ready, but the specific image node was not yet present. This caused the script to fail silently without generating an image or a JSON file.

This commit removes the incorrect `return None` statement, ensuring the polling loop continues until the image is actually available or the timeout is reached. This resolves the issue where images and JSON files were not being saved.